### PR TITLE
Hot reload of workflows

### DIFF
--- a/src/Wexflow.Core/WexflowEngine.cs
+++ b/src/Wexflow.Core/WexflowEngine.cs
@@ -20,6 +20,10 @@ namespace Wexflow.Core
         {
             SettingsFile = settingsFile;
             Workflows = new List<Workflow>();
+
+            Logger.Info("");
+            Logger.Info("Starting Wexflow Engine");
+
             LoadSettings();
             LoadWorkflows();
         }
@@ -48,7 +52,6 @@ namespace Wexflow.Core
                 if (workflow != null)
                 {
                     Workflows.Add(workflow);
-                    Logger.InfoFormat("Workflow loaded: {0} ({1})", workflow, workflow.WorkflowFilePath);
                 }
             }
 
@@ -56,7 +59,6 @@ namespace Wexflow.Core
             {
                 EnableRaisingEvents = true,
                 IncludeSubdirectories = false,
-                NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.Size
             };
 
             watcher.Created += (_, args) =>
@@ -116,7 +118,7 @@ namespace Wexflow.Core
             try
             {
                 var wf = new Workflow(file, TempFolder, XsdPath);
-                Logger.InfoFormat("Workflow loaded: {0}", wf);
+                Logger.InfoFormat("Workflow loaded: {0} ({1})", wf, file);
                 return wf;
             }
             catch (Exception e)
@@ -128,8 +130,7 @@ namespace Wexflow.Core
 
         public void Run()
         {
-            Logger.Info("");
-            Logger.Info("Starting Wexflow Engine");
+            
             foreach (Workflow workflow in Workflows)
             {
                 ScheduleWorkflow(workflow);

--- a/src/Wexflow.Core/WexflowEngine.cs
+++ b/src/Wexflow.Core/WexflowEngine.cs
@@ -90,6 +90,7 @@ namespace Wexflow.Core
                     {
                         // the existing file might have caused an error during loading, so there may be no corresponding
                         // workflow to the changed file
+                        changedWorkflow.Stop();
                         Workflows.Remove(changedWorkflow);
                     }
                     Logger.InfoFormat("A change in the definition file {0} of workflow {1} has been detected. The workflow will be reloaded", changedWorkflow.WorkflowFilePath, changedWorkflow.Name);

--- a/src/Wexflow.Core/WexflowEngine.cs
+++ b/src/Wexflow.Core/WexflowEngine.cs
@@ -16,7 +16,7 @@ namespace Wexflow.Core
         public string XsdPath { get; private set; }
         public IList<Workflow> Workflows { get; private set; }
 
-        public WexflowEngine(string settingsFile) 
+        public WexflowEngine(string settingsFile)
         {
             SettingsFile = settingsFile;
             Workflows = new List<Workflow>();
@@ -41,19 +41,28 @@ namespace Wexflow.Core
         }
 
         void LoadWorkflows()
-        { 
+        {
             foreach (string file in Directory.GetFiles(WorkflowsFolder))
             {
-                try
+                var workflow = LoadWorkflowFromFile(file);
+                if (workflow != null)
                 {
-                    var workflow = new Workflow(file, TempFolder, XsdPath);
                     Workflows.Add(workflow);
                     Logger.InfoFormat("Workflow loaded: {0} ({1})", workflow, workflow.WorkflowFilePath);
                 }
-                catch (Exception e)
-                {
-                    Logger.ErrorFormat("An error occured while loading the workflow : {0} Please check the workflow configuration. Error: {1}", file, e.Message);
-                }
+            }
+        }
+
+        Workflow LoadWorkflowFromFile(string file)
+        {
+            try
+            {
+                return new Workflow(file, TempFolder, XsdPath);
+            }
+            catch (Exception e)
+            {
+                Logger.ErrorFormat("An error occured while loading the workflow : {0} Please check the workflow configuration. Error: {1}", file, e.Message);
+                return null;
             }
         }
 
@@ -74,7 +83,7 @@ namespace Wexflow.Core
                             var wf = (Workflow)o;
                             if (!wf.IsRunning) wf.Start();
                         };
-                        
+
                         var timer = new WexflowTimer(new TimerCallback(callback), workflow, workflow.Period);
                         timer.Start();
                     }
@@ -95,7 +104,7 @@ namespace Wexflow.Core
             {
                 Logger.ErrorFormat("Workflow {0} not found.", workflowId);
             }
-            else 
+            else
             {
                 if (wf.IsEnabled) wf.Start();
             }

--- a/src/Wexflow.Core/WexflowEngine.cs
+++ b/src/Wexflow.Core/WexflowEngine.cs
@@ -14,11 +14,12 @@ namespace Wexflow.Core
         public string WorkflowsFolder { get; private set; }
         public string TempFolder { get; private set; }
         public string XsdPath { get; private set; }
-        public Workflow[] Workflows { get; private set; }
+        public IList<Workflow> Workflows { get; private set; }
 
         public WexflowEngine(string settingsFile) 
         {
             SettingsFile = settingsFile;
+            Workflows = new List<Workflow>();
             LoadSettings();
             LoadWorkflows();
         }
@@ -41,21 +42,19 @@ namespace Wexflow.Core
 
         void LoadWorkflows()
         { 
-            var workflows = new List<Workflow>();
             foreach (string file in Directory.GetFiles(WorkflowsFolder))
             {
                 try
                 {
                     var workflow = new Workflow(file, TempFolder, XsdPath);
-                    workflows.Add(workflow);
-                    Logger.InfoFormat("Workflow loaded: {0}", workflow);
+                    Workflows.Add(workflow);
+                    Logger.InfoFormat("Workflow loaded: {0} ({1})", workflow, workflow.WorkflowFilePath);
                 }
                 catch (Exception e)
                 {
                     Logger.ErrorFormat("An error occured while loading the workflow : {0} Please check the workflow configuration. Error: {1}", file, e.Message);
                 }
             }
-            Workflows = workflows.ToArray();
         }
 
         public void Run()
@@ -143,6 +142,5 @@ namespace Wexflow.Core
                 if (wf.IsEnabled) wf.Resume();
             }
         }
-
     }
 }


### PR DESCRIPTION
The wexflow engine must be restarted in order to read workflows. Running wexflow as a windows service, this means restarting the service and thus resetting all the timers of current workflows.

This PR makes the WorkflowEngine class watch for xml-file changes in the workflow dir and creates/reloads/deletes workflows as necessary.