### PR TITLE
No files without results in sql

### DIFF
--- a/src/Wexflow.Tasks.SqlToCsv/SqlToCsv.cs
+++ b/src/Wexflow.Tasks.SqlToCsv/SqlToCsv.cs
@@ -1,17 +1,17 @@
-﻿using System;
+﻿using MySql.Data.MySqlClient;
+using Npgsql;
+using Oracle.DataAccess.Client;
+using System;
 using System.Collections.Generic;
-using Wexflow.Core;
+using System.Data.OleDb;
+using System.Data.SqlClient;
+using System.Data.SQLite;
+using System.IO;
+using System.Text;
 using System.Threading;
 using System.Xml.Linq;
-using System.Data.SqlClient;
-using Oracle.DataAccess.Client;
-using MySql.Data.MySqlClient;
-using System.Data.SQLite;
-using Npgsql;
-using System.IO;
-using System.Data.OleDb;
-using System.Text;
 using Teradata.Client.Provider;
+using Wexflow.Core;
 
 namespace Wexflow.Tasks.SqlToCsv
 {
@@ -111,250 +111,267 @@ namespace Wexflow.Tasks.SqlToCsv
             {
                 case Type.SqlServer:
                     using (var conn = new SqlConnection(ConnectionString))
+                    using (var comm = new SqlCommand(sql, conn))
                     {
-                        var comm = new SqlCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
-
-                        // Get column names
-                        var columns = new List<string>();
-                        StringBuilder builder = new StringBuilder();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                            builder.Append(reader.GetName(i)).Append(Separator);
-                        }
-                        builder.Append("\r\n");
+                            var columns = new List<string>();
+                            StringBuilder builder = new StringBuilder();
 
-                        // Build Csv
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("SqlServer_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv", DateTime.Now));
-
-                        while (reader.Read())
-                        {
-                            foreach (var column in columns)
-                            {
-                                builder.Append(reader[column]).Append(Separator);
-                            }
-                            builder.Append("\r\n");
-                        }
-
-                        File.WriteAllText(destPath, builder.ToString());
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("CSV file generated: {0}", destPath);
-                    }
-                    break;
-                case Type.Access:
-                    using (var conn = new OleDbConnection(ConnectionString))
-                    {
-                        var comm = new OleDbCommand(sql, conn);
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        // Get column names
-                        var columns = new List<string>();
-                        StringBuilder builder = new StringBuilder();
-                        if (reader != null)
-                        {
                             for (int i = 0; i < reader.FieldCount; i++)
                             {
                                 columns.Add(reader.GetName(i));
                                 builder.Append(reader.GetName(i)).Append(Separator);
                             }
-                        }
-                        builder.Append("\r\n");
 
-                        // Build Csv
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("Access_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv", DateTime.Now));
-
-                        while (reader != null && reader.Read())
-                        {
-                            foreach (var column in columns)
-                            {
-                                builder.Append(reader[column]).Append(Separator);
-                            }
                             builder.Append("\r\n");
-                        }
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("SqlServer_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
+                                                           DateTime.Now));
 
-                        File.WriteAllText(destPath, builder.ToString());
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("CSV file generated: {0}", destPath);
+                            while (reader.Read())
+                            {
+                                foreach (var column in columns)
+                                {
+                                    builder.Append(reader[column]).Append(Separator);
+                                }
+                                builder.Append("\r\n");
+                            }
+
+                            File.WriteAllText(destPath, builder.ToString());
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("CSV file generated: {0}", destPath);
+                        }
+                    }
+                    break;
+                case Type.Access:
+                    using (var conn = new OleDbConnection(ConnectionString))
+                    using (var comm = new OleDbCommand(sql, conn))
+                    {
+                        conn.Open();
+                        var reader = comm.ExecuteReader();
+
+                        if (reader.HasRows)
+                        {
+                            var columns = new List<string>();
+                            StringBuilder builder = new StringBuilder();
+
+                            for (int i = 0; i < reader.FieldCount; i++)
+                            {
+                                columns.Add(reader.GetName(i));
+                                builder.Append(reader.GetName(i)).Append(Separator);
+                            }
+
+                            builder.Append("\r\n");
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("Access_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
+                                                           DateTime.Now));
+
+                            while (reader.Read())
+                            {
+                                foreach (var column in columns)
+                                {
+                                    builder.Append(reader[column]).Append(Separator);
+                                }
+                                builder.Append("\r\n");
+                            }
+
+                            File.WriteAllText(destPath, builder.ToString());
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("CSV file generated: {0}", destPath);
+                        }
                     }
                     break;
                 case Type.Oracle:
                     using (var conn = new OracleConnection(ConnectionString))
+                    using (var comm = new OracleCommand(sql, conn))
                     {
-                        var comm = new OracleCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
 
-                        // Get column names
-                        var columns = new List<string>();
-                        StringBuilder builder = new StringBuilder();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                            builder.Append(reader.GetName(i)).Append(Separator);
-                        }
-                        builder.Append("\r\n");
+                            var columns = new List<string>();
+                            StringBuilder builder = new StringBuilder();
 
-                        // Build Csv
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("Oracle_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv", DateTime.Now));
-
-                        while (reader.Read())
-                        {
-                            foreach (var column in columns)
+                            for (int i = 0; i < reader.FieldCount; i++)
                             {
-                                builder.Append(reader[column]).Append(Separator);
+                                columns.Add(reader.GetName(i));
+                                builder.Append(reader.GetName(i)).Append(Separator);
                             }
-                            builder.Append("\r\n");
-                        }
 
-                        File.WriteAllText(destPath, builder.ToString());
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("CSV file generated: {0}", destPath);
+                            builder.Append("\r\n");
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("Oracle_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
+                                                           DateTime.Now));
+
+                            while (reader.Read())
+                            {
+                                foreach (var column in columns)
+                                {
+                                    builder.Append(reader[column]).Append(Separator);
+                                }
+                                builder.Append("\r\n");
+                            }
+
+                            File.WriteAllText(destPath, builder.ToString());
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("CSV file generated: {0}", destPath);
+                        }
                     }
                     break;
                 case Type.MySql:
                     using (var conn = new MySqlConnection(ConnectionString))
+                    using (var comm = new MySqlCommand(sql, conn))
                     {
-                        var comm = new MySqlCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
 
-                        // Get column names
-                        var columns = new List<string>();
-                        StringBuilder builder = new StringBuilder();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                            builder.Append(reader.GetName(i)).Append(Separator);
-                        }
-                        builder.Append("\r\n");
+                            var columns = new List<string>();
+                            StringBuilder builder = new StringBuilder();
 
-                        // Build Csv
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("MySql_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv", DateTime.Now));
-
-                        while (reader.Read())
-                        {
-                            foreach (var column in columns)
+                            for (int i = 0; i < reader.FieldCount; i++)
                             {
-                                builder.Append(reader[column]).Append(Separator);
+                                columns.Add(reader.GetName(i));
+                                builder.Append(reader.GetName(i)).Append(Separator);
                             }
-                            builder.Append("\r\n");
-                        }
 
-                        File.WriteAllText(destPath, builder.ToString());
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("CSV file generated: {0}", destPath);
+                            builder.Append("\r\n");
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("MySql_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
+                                                           DateTime.Now));
+
+                            while (reader.Read())
+                            {
+                                foreach (var column in columns)
+                                {
+                                    builder.Append(reader[column]).Append(Separator);
+                                }
+                                builder.Append("\r\n");
+                            }
+
+                            File.WriteAllText(destPath, builder.ToString());
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("CSV file generated: {0}", destPath);
+                        }
                     }
                     break;
                 case Type.Sqlite:
                     using (var conn = new SQLiteConnection(ConnectionString))
+                    using (var comm = new SQLiteCommand(sql, conn))
                     {
-                        var comm = new SQLiteCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
 
-                        // Get column names
-                        var columns = new List<string>();
-                        StringBuilder builder = new StringBuilder();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                            builder.Append(reader.GetName(i)).Append(Separator);
-                        }
-                        builder.Append("\r\n");
+                            var columns = new List<string>();
+                            StringBuilder builder = new StringBuilder();
 
-                        // Build Csv
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("Sqlite_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv", DateTime.Now));
-                       
-                        while (reader.Read())
-                        {
-                            foreach (var column in columns)
+                            for (int i = 0; i < reader.FieldCount; i++)
                             {
-                                builder.Append(reader[column]).Append(Separator);
+                                columns.Add(reader.GetName(i));
+                                builder.Append(reader.GetName(i)).Append(Separator);
                             }
+
                             builder.Append("\r\n");
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("Sqlite_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
+                                                           DateTime.Now));
+
+                            while (reader.Read())
+                            {
+                                foreach (var column in columns)
+                                {
+                                    builder.Append(reader[column]).Append(Separator);
+                                }
+                                builder.Append("\r\n");
+                            }
+
+                            File.WriteAllText(destPath, builder.ToString());
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("CSV file generated: {0}", destPath);
                         }
-                        
-                        File.WriteAllText(destPath, builder.ToString());
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("CSV file generated: {0}", destPath);
                     }
                     break;
                 case Type.PostGreSql:
                     using (var conn = new NpgsqlConnection(ConnectionString))
+                    using (var comm = new NpgsqlCommand(sql, conn))
                     {
-                        var comm = new NpgsqlCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
 
-                        // Get column names
-                        var columns = new List<string>();
-                        StringBuilder builder = new StringBuilder();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                            builder.Append(reader.GetName(i)).Append(Separator);
-                        }
-                        builder.Append("\r\n");
+                            var columns = new List<string>();
+                            StringBuilder builder = new StringBuilder();
 
-                        // Build Csv
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("PostGreSql_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv", DateTime.Now));
-
-                        while (reader.Read())
-                        {
-                            foreach (var column in columns)
+                            for (int i = 0; i < reader.FieldCount; i++)
                             {
-                                builder.Append(reader[column]).Append(Separator);
+                                columns.Add(reader.GetName(i));
+                                builder.Append(reader.GetName(i)).Append(Separator);
                             }
-                            builder.Append("\r\n");
-                        }
 
-                        File.WriteAllText(destPath, builder.ToString());
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("CSV file generated: {0}", destPath);
+                            builder.Append("\r\n");
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("PostGreSql_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
+                                                           DateTime.Now));
+
+                            while (reader.Read())
+                            {
+                                foreach (var column in columns)
+                                {
+                                    builder.Append(reader[column]).Append(Separator);
+                                }
+                                builder.Append("\r\n");
+                            }
+
+                            File.WriteAllText(destPath, builder.ToString());
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("CSV file generated: {0}", destPath);
+                        }
                     }
                     break;
                 case Type.Teradata:
                     using (var conn = new TdConnection(ConnectionString))
+                    using (var comm = new TdCommand(sql, conn))
                     {
-                        var comm = new TdCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
 
-                        // Get column names
-                        var columns = new List<string>();
-                        StringBuilder builder = new StringBuilder();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                            builder.Append(reader.GetName(i)).Append(Separator);
-                        }
-                        builder.Append("\r\n");
+                            var columns = new List<string>();
+                            StringBuilder builder = new StringBuilder();
 
-                        // Build Csv
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("Teradata_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv", DateTime.Now));
-
-                        while (reader.Read())
-                        {
-                            foreach (var column in columns)
+                            for (int i = 0; i < reader.FieldCount; i++)
                             {
-                                builder.Append(reader[column]).Append(Separator);
+                                columns.Add(reader.GetName(i));
+                                builder.Append(reader.GetName(i)).Append(Separator);
                             }
-                            builder.Append("\r\n");
-                        }
 
-                        File.WriteAllText(destPath, builder.ToString());
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("CSV file generated: {0}", destPath);
+                            builder.Append("\r\n");
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("Teradata_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
+                                                           DateTime.Now));
+
+                            while (reader.Read())
+                            {
+                                foreach (var column in columns)
+                                {
+                                    builder.Append(reader[column]).Append(Separator);
+                                }
+                                builder.Append("\r\n");
+                            }
+
+                            File.WriteAllText(destPath, builder.ToString());
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("CSV file generated: {0}", destPath);
+                        }
                     }
                     break;
             }

--- a/src/Wexflow.Tasks.SqlToCsv/SqlToCsv.cs
+++ b/src/Wexflow.Tasks.SqlToCsv/SqlToCsv.cs
@@ -3,6 +3,7 @@ using Npgsql;
 using Oracle.DataAccess.Client;
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Data.OleDb;
 using System.Data.SqlClient;
 using System.Data.SQLite;
@@ -110,270 +111,90 @@ namespace Wexflow.Tasks.SqlToCsv
             switch (DbType)
             {
                 case Type.SqlServer:
-                    using (var conn = new SqlConnection(ConnectionString))
-                    using (var comm = new SqlCommand(sql, conn))
+                    using (var connection = new SqlConnection(ConnectionString))
+                    using (var command = new SqlCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-                            StringBuilder builder = new StringBuilder();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                                builder.Append(reader.GetName(i)).Append(Separator);
-                            }
-
-                            builder.Append("\r\n");
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("SqlServer_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
-                                                           DateTime.Now));
-
-                            while (reader.Read())
-                            {
-                                foreach (var column in columns)
-                                {
-                                    builder.Append(reader[column]).Append(Separator);
-                                }
-                                builder.Append("\r\n");
-                            }
-
-                            File.WriteAllText(destPath, builder.ToString());
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("CSV file generated: {0}", destPath);
-                        }
+                        ConvertToCsv(connection, command);
                     }
                     break;
                 case Type.Access:
-                    using (var conn = new OleDbConnection(ConnectionString))
-                    using (var comm = new OleDbCommand(sql, conn))
+                    using (var connection = new OleDbConnection(ConnectionString))
+                    using (var command = new OleDbCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-                            StringBuilder builder = new StringBuilder();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                                builder.Append(reader.GetName(i)).Append(Separator);
-                            }
-
-                            builder.Append("\r\n");
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("Access_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
-                                                           DateTime.Now));
-
-                            while (reader.Read())
-                            {
-                                foreach (var column in columns)
-                                {
-                                    builder.Append(reader[column]).Append(Separator);
-                                }
-                                builder.Append("\r\n");
-                            }
-
-                            File.WriteAllText(destPath, builder.ToString());
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("CSV file generated: {0}", destPath);
-                        }
+                        ConvertToCsv(connection, command);
                     }
                     break;
                 case Type.Oracle:
-                    using (var conn = new OracleConnection(ConnectionString))
-                    using (var comm = new OracleCommand(sql, conn))
+                    using (var connection = new OracleConnection(ConnectionString))
+                    using (var command = new OracleCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-                            StringBuilder builder = new StringBuilder();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                                builder.Append(reader.GetName(i)).Append(Separator);
-                            }
-
-                            builder.Append("\r\n");
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("Oracle_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
-                                                           DateTime.Now));
-
-                            while (reader.Read())
-                            {
-                                foreach (var column in columns)
-                                {
-                                    builder.Append(reader[column]).Append(Separator);
-                                }
-                                builder.Append("\r\n");
-                            }
-
-                            File.WriteAllText(destPath, builder.ToString());
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("CSV file generated: {0}", destPath);
-                        }
+                        ConvertToCsv(connection, command);
                     }
                     break;
                 case Type.MySql:
-                    using (var conn = new MySqlConnection(ConnectionString))
-                    using (var comm = new MySqlCommand(sql, conn))
+                    using (var connection = new MySqlConnection(ConnectionString))
+                    using (var command = new MySqlCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-                            StringBuilder builder = new StringBuilder();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                                builder.Append(reader.GetName(i)).Append(Separator);
-                            }
-
-                            builder.Append("\r\n");
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("MySql_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
-                                                           DateTime.Now));
-
-                            while (reader.Read())
-                            {
-                                foreach (var column in columns)
-                                {
-                                    builder.Append(reader[column]).Append(Separator);
-                                }
-                                builder.Append("\r\n");
-                            }
-
-                            File.WriteAllText(destPath, builder.ToString());
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("CSV file generated: {0}", destPath);
-                        }
+                        ConvertToCsv(connection, command);
                     }
                     break;
                 case Type.Sqlite:
-                    using (var conn = new SQLiteConnection(ConnectionString))
-                    using (var comm = new SQLiteCommand(sql, conn))
+                    using (var connection = new SQLiteConnection(ConnectionString))
+                    using (var command = new SQLiteCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-                            StringBuilder builder = new StringBuilder();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                                builder.Append(reader.GetName(i)).Append(Separator);
-                            }
-
-                            builder.Append("\r\n");
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("Sqlite_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
-                                                           DateTime.Now));
-
-                            while (reader.Read())
-                            {
-                                foreach (var column in columns)
-                                {
-                                    builder.Append(reader[column]).Append(Separator);
-                                }
-                                builder.Append("\r\n");
-                            }
-
-                            File.WriteAllText(destPath, builder.ToString());
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("CSV file generated: {0}", destPath);
-                        }
+                        ConvertToCsv(connection, command);
                     }
                     break;
                 case Type.PostGreSql:
-                    using (var conn = new NpgsqlConnection(ConnectionString))
-                    using (var comm = new NpgsqlCommand(sql, conn))
+                    using (var connection = new NpgsqlConnection(ConnectionString))
+                    using (var command = new NpgsqlCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-                            StringBuilder builder = new StringBuilder();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                                builder.Append(reader.GetName(i)).Append(Separator);
-                            }
-
-                            builder.Append("\r\n");
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("PostGreSql_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
-                                                           DateTime.Now));
-
-                            while (reader.Read())
-                            {
-                                foreach (var column in columns)
-                                {
-                                    builder.Append(reader[column]).Append(Separator);
-                                }
-                                builder.Append("\r\n");
-                            }
-
-                            File.WriteAllText(destPath, builder.ToString());
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("CSV file generated: {0}", destPath);
-                        }
+                        ConvertToCsv(connection, command);
                     }
                     break;
                 case Type.Teradata:
-                    using (var conn = new TdConnection(ConnectionString))
-                    using (var comm = new TdCommand(sql, conn))
+                    using (var connection = new TdConnection(ConnectionString))
+                    using (var command = new TdCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-                            StringBuilder builder = new StringBuilder();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                                builder.Append(reader.GetName(i)).Append(Separator);
-                            }
-
-                            builder.Append("\r\n");
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("Teradata_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
-                                                           DateTime.Now));
-
-                            while (reader.Read())
-                            {
-                                foreach (var column in columns)
-                                {
-                                    builder.Append(reader[column]).Append(Separator);
-                                }
-                                builder.Append("\r\n");
-                            }
-
-                            File.WriteAllText(destPath, builder.ToString());
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("CSV file generated: {0}", destPath);
-                        }
+                        ConvertToCsv(connection, command);
                     }
                     break;
+            }
+        }
+
+        private void ConvertToCsv(DbConnection conn, DbCommand comm)
+        {
+            conn.Open();
+            var reader = comm.ExecuteReader();
+
+            if (reader.HasRows)
+            {
+                var columns = new List<string>();
+                StringBuilder builder = new StringBuilder();
+
+                for (int i = 0; i < reader.FieldCount; i++)
+                {
+                    columns.Add(reader.GetName(i));
+                    builder.Append(reader.GetName(i)).Append(Separator);
+                }
+
+                builder.Append("\r\n");
+                string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                               string.Format("SqlServer_{0:yyyy-MM-dd-HH-mm-ss-fff}.csv",
+                                               DateTime.Now));
+
+                while (reader.Read())
+                {
+                    foreach (var column in columns)
+                    {
+                        builder.Append(reader[column]).Append(Separator);
+                    }
+                    builder.Append("\r\n");
+                }
+
+                File.WriteAllText(destPath, builder.ToString());
+                Files.Add(new FileInf(destPath, Id));
+                InfoFormat("CSV file generated: {0}", destPath);
             }
         }
     }

--- a/src/Wexflow.Tasks.SqlToXml/SqlToXml.cs
+++ b/src/Wexflow.Tasks.SqlToXml/SqlToXml.cs
@@ -3,6 +3,7 @@ using Npgsql;
 using Oracle.DataAccess.Client;
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Data.OleDb;
 using System.Data.SqlClient;
 using System.Data.SQLite;
@@ -108,281 +109,91 @@ namespace Wexflow.Tasks.SqlToXml
             switch (DbType)
             {
                 case Type.SqlServer:
-                    using (var conn = new SqlConnection(ConnectionString))
-                    using (var comm = new SqlCommand(sql, conn))
+                    using (var connection = new SqlConnection(ConnectionString))
+                    using (var command = new SqlCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                            }
-
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("SqlServer_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
-                                                           DateTime.Now));
-                            var xdoc = new XDocument();
-                            var xobjects = new XElement("Records");
-
-                            while (reader.Read())
-                            {
-                                var xobject = new XElement("Record");
-
-                                foreach (var column in columns)
-                                {
-                                    //xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column) , new XAttribute("value", SecurityElement.Escape(reader[column].ToString())))));
-                                }
-                                xobjects.Add(xobject);
-                            }
-                            xdoc.Add(xobjects);
-                            xdoc.Save(destPath);
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("XML file generated: {0}", destPath);
-                        }
+                        ConvertToXML(connection, command);
                     }
                     break;
                 case Type.Access:
                     using (var conn = new OleDbConnection(ConnectionString))
                     using (var comm = new OleDbCommand(sql, conn))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-
-                            if (reader != null)
-                            {
-                                for (int i = 0; i < reader.FieldCount; i++)
-                                {
-                                    columns.Add(reader.GetName(i));
-                                }
-                            }
-
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("Access_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
-                                                           DateTime.Now));
-                            var xdoc = new XDocument();
-                            var xobjects = new XElement("Records");
-
-                            while (reader != null && reader.Read())
-                            {
-                                var xobject = new XElement("Record");
-
-                                foreach (var column in columns)
-                                {
-                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
-                                }
-                                xobjects.Add(xobject);
-                            }
-                            xdoc.Add(xobjects);
-                            xdoc.Save(destPath);
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("XML file generated: {0}", destPath);
-                        }
+                        ConvertToXML(conn, comm);
                     }
                     break;
                 case Type.Oracle:
-                    using (var conn = new OracleConnection(ConnectionString))
-                    using (var comm = new OracleCommand(sql, conn))
+                    using (var connection = new OracleConnection(ConnectionString))
+                    using (var command = new OracleCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                            }
-
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("Oracle_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
-                                                           DateTime.Now));
-                            var xdoc = new XDocument();
-                            var xobjects = new XElement("Records");
-
-                            while (reader.Read())
-                            {
-                                var xobject = new XElement("Record");
-
-                                foreach (var column in columns)
-                                {
-                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
-                                }
-                                xobjects.Add(xobject);
-                            }
-                            xdoc.Add(xobjects);
-                            xdoc.Save(destPath);
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("XML file generated: {0}", destPath);
-                        }
+                        ConvertToXML(connection, command);
                     }
                     break;
                 case Type.MySql:
-                    using (var conn = new MySqlConnection(ConnectionString))
-                    using (var comm = new MySqlCommand(sql, conn))
+                    using (var connection = new MySqlConnection(ConnectionString))
+                    using (var command = new MySqlCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                            }
-
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("MySql_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
-                                                           DateTime.Now));
-                            var xdoc = new XDocument();
-                            var xobjects = new XElement("Records");
-
-                            while (reader.Read())
-                            {
-                                var xobject = new XElement("Record");
-
-                                foreach (var column in columns)
-                                {
-                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
-                                }
-                                xobjects.Add(xobject);
-                            }
-                            xdoc.Add(xobjects);
-                            xdoc.Save(destPath);
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("XML file generated: {0}", destPath);
-                        }
+                        ConvertToXML(connection, command);
                     }
                     break;
                 case Type.Sqlite:
-                    using (var conn = new SQLiteConnection(ConnectionString))
-                    using (var comm = new SQLiteCommand(sql, conn))
+                    using (var connection = new SQLiteConnection(ConnectionString))
+                    using (var command = new SQLiteCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                            }
-
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("Sqlite_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
-                                                           DateTime.Now));
-                            var xdoc = new XDocument();
-                            var xobjects = new XElement("Records");
-
-                            while (reader.Read())
-                            {
-                                var xobject = new XElement("Record");
-
-                                foreach (var column in columns)
-                                {
-                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
-                                }
-                                xobjects.Add(xobject);
-                            }
-                            xdoc.Add(xobjects);
-                            xdoc.Save(destPath);
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("XML file generated: {0}", destPath);
-                        }
+                        ConvertToXML(connection, command);
                     }
                     break;
                 case Type.PostGreSql:
-                    using (var conn = new NpgsqlConnection(ConnectionString))
-                    using (var comm = new NpgsqlCommand(sql, conn))
+                    using (var connection = new NpgsqlConnection(ConnectionString))
+                    using (var command = new NpgsqlCommand(sql, connection))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                            }
-
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("PostGreSql_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
-                                                           DateTime.Now));
-                            var xdoc = new XDocument();
-                            var xobjects = new XElement("Records");
-
-                            while (reader.Read())
-                            {
-                                var xobject = new XElement("Record");
-
-                                foreach (var column in columns)
-                                {
-                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
-                                }
-                                xobjects.Add(xobject);
-                            }
-                            xdoc.Add(xobjects);
-                            xdoc.Save(destPath);
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("XML file generated: {0}", destPath);
-                        }
+                        ConvertToXML(connection, command);
                     }
                     break;
                 case Type.Teradata:
-                    using (var conn = new TdConnection(ConnectionString))
-                    using (var comm = new TdCommand(sql, conn))
+                    using (var connenction = new TdConnection(ConnectionString))
+                    using (var command = new TdCommand(sql, connenction))
                     {
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        if (reader.HasRows)
-                        {
-                            var columns = new List<string>();
-
-                            for (int i = 0; i < reader.FieldCount; i++)
-                            {
-                                columns.Add(reader.GetName(i));
-                            }
-
-                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
-                                                           string.Format("Teradata_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
-                                                           DateTime.Now));
-                            var xdoc = new XDocument();
-                            var xobjects = new XElement("Records");
-
-                            while (reader.Read())
-                            {
-                                var xobject = new XElement("Record");
-
-                                foreach (var column in columns)
-                                {
-                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
-                                }
-                                xobjects.Add(xobject);
-                            }
-                            xdoc.Add(xobjects);
-                            xdoc.Save(destPath);
-                            Files.Add(new FileInf(destPath, Id));
-                            InfoFormat("XML file generated: {0}", destPath);
-                        }
+                        ConvertToXML(connenction, command);
                     }
                     break;
+            }
+        }
+
+        private void ConvertToXML(DbConnection connection, DbCommand command)
+        {
+            connection.Open();
+            var reader = command.ExecuteReader();
+
+            if (reader.HasRows)
+            {
+                var columns = new List<string>();
+
+                for (int i = 0; i < reader.FieldCount; i++)
+                {
+                    columns.Add(reader.GetName(i));
+                }
+
+                string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                               string.Format("SqlServer_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
+                                               DateTime.Now));
+                var xdoc = new XDocument();
+                var xobjects = new XElement("Records");
+
+                while (reader.Read())
+                {
+                    var xobject = new XElement("Record");
+
+                    foreach (var column in columns)
+                    {
+                        //xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column) , new XAttribute("value", SecurityElement.Escape(reader[column].ToString())))));
+                    }
+                    xobjects.Add(xobject);
+                }
+                xdoc.Add(xobjects);
+                xdoc.Save(destPath);
+                Files.Add(new FileInf(destPath, Id));
+                InfoFormat("XML file generated: {0}", destPath);
             }
         }
     }

--- a/src/Wexflow.Tasks.SqlToXml/SqlToXml.cs
+++ b/src/Wexflow.Tasks.SqlToXml/SqlToXml.cs
@@ -1,17 +1,17 @@
-﻿using System;
+﻿using MySql.Data.MySqlClient;
+using Npgsql;
+using Oracle.DataAccess.Client;
+using System;
 using System.Collections.Generic;
-using Wexflow.Core;
+using System.Data.OleDb;
+using System.Data.SqlClient;
+using System.Data.SQLite;
+using System.IO;
+using System.Security;
 using System.Threading;
 using System.Xml.Linq;
-using System.Data.SqlClient;
-using Oracle.DataAccess.Client;
-using MySql.Data.MySqlClient;
-using System.Data.SQLite;
-using Npgsql;
-using System.IO;
-using System.Data.OleDb;
-using System.Security;
 using Teradata.Client.Provider;
+using Wexflow.Core;
 
 namespace Wexflow.Tasks.SqlToXml
 {
@@ -109,243 +109,278 @@ namespace Wexflow.Tasks.SqlToXml
             {
                 case Type.SqlServer:
                     using (var conn = new SqlConnection(ConnectionString))
+                    using (var comm = new SqlCommand(sql, conn))
                     {
-                        var comm = new SqlCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
 
-                        // Get column names
-                        var columns = new List<string>();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                        }
+                            var columns = new List<string>();
 
-                        // Build Xml
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("SqlServer_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml", DateTime.Now));
-                        var xdoc = new XDocument();
-                        var xobjects = new XElement("Records");
-                        while (reader.Read())
-                        {
-                            var xobject = new XElement("Record");
-                            foreach (var column in columns)
-                            {
-                                //xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column) , new XAttribute("value", SecurityElement.Escape(reader[column].ToString())))));
-                            }
-                            xobjects.Add(xobject);
-                        }
-                        xdoc.Add(xobjects);
-                        xdoc.Save(destPath);
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("XML file generated: {0}", destPath);
-                    }
-                    break;
-                case Type.Access:
-                    using (var conn = new OleDbConnection(ConnectionString))
-                    {
-                        var comm = new OleDbCommand(sql, conn);
-                        conn.Open();
-                        var reader = comm.ExecuteReader();
-
-                        // Get column names
-                        var columns = new List<string>();
-                        if (reader != null)
-                        {
                             for (int i = 0; i < reader.FieldCount; i++)
                             {
                                 columns.Add(reader.GetName(i));
                             }
-                        }
 
-                        // Build Xml
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("Access_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml", DateTime.Now));
-                        var xdoc = new XDocument();
-                        var xobjects = new XElement("Records");
-                        while (reader != null && reader.Read())
-                        {
-                            var xobject = new XElement("Record");
-                            foreach (var column in columns)
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("SqlServer_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
+                                                           DateTime.Now));
+                            var xdoc = new XDocument();
+                            var xobjects = new XElement("Records");
+
+                            while (reader.Read())
                             {
-                                xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                var xobject = new XElement("Record");
+
+                                foreach (var column in columns)
+                                {
+                                    //xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column) , new XAttribute("value", SecurityElement.Escape(reader[column].ToString())))));
+                                }
+                                xobjects.Add(xobject);
                             }
-                            xobjects.Add(xobject);
+                            xdoc.Add(xobjects);
+                            xdoc.Save(destPath);
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("XML file generated: {0}", destPath);
                         }
-                        xdoc.Add(xobjects);
-                        xdoc.Save(destPath);
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("XML file generated: {0}", destPath);
+                    }
+                    break;
+                case Type.Access:
+                    using (var conn = new OleDbConnection(ConnectionString))
+                    using (var comm = new OleDbCommand(sql, conn))
+                    {
+                        conn.Open();
+                        var reader = comm.ExecuteReader();
+
+                        if (reader.HasRows)
+                        {
+                            var columns = new List<string>();
+
+                            if (reader != null)
+                            {
+                                for (int i = 0; i < reader.FieldCount; i++)
+                                {
+                                    columns.Add(reader.GetName(i));
+                                }
+                            }
+
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("Access_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
+                                                           DateTime.Now));
+                            var xdoc = new XDocument();
+                            var xobjects = new XElement("Records");
+
+                            while (reader != null && reader.Read())
+                            {
+                                var xobject = new XElement("Record");
+
+                                foreach (var column in columns)
+                                {
+                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                }
+                                xobjects.Add(xobject);
+                            }
+                            xdoc.Add(xobjects);
+                            xdoc.Save(destPath);
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("XML file generated: {0}", destPath);
+                        }
                     }
                     break;
                 case Type.Oracle:
                     using (var conn = new OracleConnection(ConnectionString))
+                    using (var comm = new OracleCommand(sql, conn))
                     {
-                        var comm = new OracleCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
 
-                        // Get column names
-                        var columns = new List<string>();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                        }
+                            var columns = new List<string>();
 
-                        // Build Xml
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("Oracle_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml", DateTime.Now));
-                        var xdoc = new XDocument();
-                        var xobjects = new XElement("Records");
-                        while (reader.Read())
-                        {
-                            var xobject = new XElement("Record");
-                            foreach (var column in columns)
+                            for (int i = 0; i < reader.FieldCount; i++)
                             {
-                                xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                columns.Add(reader.GetName(i));
                             }
-                            xobjects.Add(xobject);
+
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("Oracle_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
+                                                           DateTime.Now));
+                            var xdoc = new XDocument();
+                            var xobjects = new XElement("Records");
+
+                            while (reader.Read())
+                            {
+                                var xobject = new XElement("Record");
+
+                                foreach (var column in columns)
+                                {
+                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                }
+                                xobjects.Add(xobject);
+                            }
+                            xdoc.Add(xobjects);
+                            xdoc.Save(destPath);
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("XML file generated: {0}", destPath);
                         }
-                        xdoc.Add(xobjects);
-                        xdoc.Save(destPath);
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("XML file generated: {0}", destPath);
                     }
                     break;
                 case Type.MySql:
                     using (var conn = new MySqlConnection(ConnectionString))
+                    using (var comm = new MySqlCommand(sql, conn))
                     {
-                        var comm = new MySqlCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
 
-                        // Get column names
-                        var columns = new List<string>();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                        }
+                            var columns = new List<string>();
 
-                        // Build Xml
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("MySql_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml", DateTime.Now));
-                        var xdoc = new XDocument();
-                        var xobjects = new XElement("Records");
-                        while (reader.Read())
-                        {
-                            var xobject = new XElement("Record");
-                            foreach (var column in columns)
+                            for (int i = 0; i < reader.FieldCount; i++)
                             {
-                                xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                columns.Add(reader.GetName(i));
                             }
-                            xobjects.Add(xobject);
+
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("MySql_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
+                                                           DateTime.Now));
+                            var xdoc = new XDocument();
+                            var xobjects = new XElement("Records");
+
+                            while (reader.Read())
+                            {
+                                var xobject = new XElement("Record");
+
+                                foreach (var column in columns)
+                                {
+                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                }
+                                xobjects.Add(xobject);
+                            }
+                            xdoc.Add(xobjects);
+                            xdoc.Save(destPath);
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("XML file generated: {0}", destPath);
                         }
-                        xdoc.Add(xobjects);
-                        xdoc.Save(destPath);
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("XML file generated: {0}", destPath);
                     }
                     break;
                 case Type.Sqlite:
                     using (var conn = new SQLiteConnection(ConnectionString))
+                    using (var comm = new SQLiteCommand(sql, conn))
                     {
-                        var comm = new SQLiteCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
 
-                        // Get column names
-                        var columns = new List<string>();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                        }
+                            var columns = new List<string>();
 
-                        // Build Xml
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("Sqlite_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml", DateTime.Now));
-                        var xdoc = new XDocument();
-                        var xobjects = new XElement("Records");
-                        while (reader.Read())
-                        {
-                            var xobject = new XElement("Record");
-                            foreach (var column in columns)
+                            for (int i = 0; i < reader.FieldCount; i++)
                             {
-                                xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                columns.Add(reader.GetName(i));
                             }
-                            xobjects.Add(xobject);
+
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("Sqlite_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
+                                                           DateTime.Now));
+                            var xdoc = new XDocument();
+                            var xobjects = new XElement("Records");
+
+                            while (reader.Read())
+                            {
+                                var xobject = new XElement("Record");
+
+                                foreach (var column in columns)
+                                {
+                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                }
+                                xobjects.Add(xobject);
+                            }
+                            xdoc.Add(xobjects);
+                            xdoc.Save(destPath);
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("XML file generated: {0}", destPath);
                         }
-                        xdoc.Add(xobjects);
-                        xdoc.Save(destPath);
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("XML file generated: {0}", destPath);
                     }
                     break;
                 case Type.PostGreSql:
                     using (var conn = new NpgsqlConnection(ConnectionString))
+                    using (var comm = new NpgsqlCommand(sql, conn))
                     {
-                        var comm = new NpgsqlCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
 
-                        // Get column names
-                        var columns = new List<string>();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                        }
+                            var columns = new List<string>();
 
-                        // Build Xml
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("PostGreSql_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml", DateTime.Now));
-                        var xdoc = new XDocument();
-                        var xobjects = new XElement("Records");
-                        while (reader.Read())
-                        {
-                            var xobject = new XElement("Record");
-                            foreach (var column in columns)
+                            for (int i = 0; i < reader.FieldCount; i++)
                             {
-                                xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                columns.Add(reader.GetName(i));
                             }
-                            xobjects.Add(xobject);
+
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("PostGreSql_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
+                                                           DateTime.Now));
+                            var xdoc = new XDocument();
+                            var xobjects = new XElement("Records");
+
+                            while (reader.Read())
+                            {
+                                var xobject = new XElement("Record");
+
+                                foreach (var column in columns)
+                                {
+                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                }
+                                xobjects.Add(xobject);
+                            }
+                            xdoc.Add(xobjects);
+                            xdoc.Save(destPath);
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("XML file generated: {0}", destPath);
                         }
-                        xdoc.Add(xobjects);
-                        xdoc.Save(destPath);
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("XML file generated: {0}", destPath);
                     }
                     break;
                 case Type.Teradata:
                     using (var conn = new TdConnection(ConnectionString))
+                    using (var comm = new TdCommand(sql, conn))
                     {
-                        var comm = new TdCommand(sql, conn);
                         conn.Open();
                         var reader = comm.ExecuteReader();
 
-                        // Get column names
-                        var columns = new List<string>();
-                        for (int i = 0; i < reader.FieldCount; i++)
+                        if (reader.HasRows)
                         {
-                            columns.Add(reader.GetName(i));
-                        }
+                            var columns = new List<string>();
 
-                        // Build Xml
-                        string destPath = Path.Combine(Workflow.WorkflowTempFolder
-                            , string.Format("Teradata_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml", DateTime.Now));
-                        var xdoc = new XDocument();
-                        var xobjects = new XElement("Records");
-                        while (reader.Read())
-                        {
-                            var xobject = new XElement("Record");
-                            foreach (var column in columns)
+                            for (int i = 0; i < reader.FieldCount; i++)
                             {
-                                xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                columns.Add(reader.GetName(i));
                             }
-                            xobjects.Add(xobject);
+
+                            string destPath = Path.Combine(Workflow.WorkflowTempFolder,
+                                                           string.Format("Teradata_{0:yyyy-MM-dd-HH-mm-ss-fff}.xml",
+                                                           DateTime.Now));
+                            var xdoc = new XDocument();
+                            var xobjects = new XElement("Records");
+
+                            while (reader.Read())
+                            {
+                                var xobject = new XElement("Record");
+
+                                foreach (var column in columns)
+                                {
+                                    xobject.Add(new XElement("Cell", new XAttribute("column", SecurityElement.Escape(column)), new XAttribute("value", SecurityElement.Escape(reader[column].ToString()))));
+                                }
+                                xobjects.Add(xobject);
+                            }
+                            xdoc.Add(xobjects);
+                            xdoc.Save(destPath);
+                            Files.Add(new FileInf(destPath, Id));
+                            InfoFormat("XML file generated: {0}", destPath);
                         }
-                        xdoc.Add(xobjects);
-                        xdoc.Save(destPath);
-                        Files.Add(new FileInf(destPath, Id));
-                        InfoFormat("XML file generated: {0}", destPath);
                     }
                     break;
             }


### PR DESCRIPTION
In my opinion an SQL-Query that returns no results should neither create a csv file nor an xml file. So I changed the SQLtoCSV and SQLtoXML tasks accordingly. This would allow workflows to react to no results instead of reacting to empty datasets in files that are always created