### PR TITLE
Zip auto name

### DIFF
--- a/src/Wexflow.Tasks.FilesRenamer/FilesRenamer.cs
+++ b/src/Wexflow.Tasks.FilesRenamer/FilesRenamer.cs
@@ -60,6 +60,7 @@ namespace Wexflow.Tasks.FilesRenamer
                         file.Path = destPath;
                         file.RenameTo = string.Empty;
                         if (!atLeastOneSucceed) atLeastOneSucceed = true;
+                        Files.Add(new FileInf(destPath, file.TaskId));
                     }
                 }
                 catch (ThreadAbortException)

--- a/src/Wexflow.Tasks.Zip/Zip.cs
+++ b/src/Wexflow.Tasks.Zip/Zip.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace Wexflow.Tasks.Zip
 {
-    public class Zip:Task
+    public class Zip : Task
     {
         public string ZipFileName { get; private set; }
 
@@ -24,8 +24,13 @@ namespace Wexflow.Tasks.Zip
             bool success = true;
 
             var files = SelectFiles();
-            if(files.Length > 0)
+            if (files.Length > 0)
             {
+                if (string.IsNullOrEmpty(ZipFileName))
+                {
+                    var fileName = Path.GetFileNameWithoutExtension(files[0].FileName);
+                    ZipFileName = fileName + ".zip";
+                }
                 var zipPath = Path.Combine(Workflow.WorkflowTempFolder, ZipFileName);
 
                 try
@@ -40,7 +45,7 @@ namespace Wexflow.Tasks.Zip
                         {
                             // Using GetFileName makes the result compatible with XP
                             // as the resulting path is not absolute.
-                            var entry = new ZipEntry(Path.GetFileName(file.Path)) {DateTime = DateTime.Now};
+                            var entry = new ZipEntry(Path.GetFileName(file.Path)) { DateTime = DateTime.Now };
 
                             // Setup the entry data as required.
 


### PR DESCRIPTION
This pull requests allows the output zip file name to be left blank or not specified. When this is the case the output zip file name will use the input file name, without its file extension, as the name for the output zip file name.

This feature allows for work flows with renamed files to be used to create zip files with dynamic names using the renamed files.

For example, consider:

- <Task id="1" name="SqlToCsv"...
- <Task id="2" name="ListFiles"
- <Task id="3" name="Xslt"
- <Task id="4" name="FilesRenamer" 

Which creates a CSV from a sql query, outputs the filenames to xml in task 2, generates new files names with Xslt in task 3 and renames them in task 4.

Now the requirement might be to zip the file and upload to FTP and the zip file name is required to follow the format created by the XSLT.

- <Task id="5" name="Zip" 
--<Task id="6" name="Ftp"

Otherwise only static file names can be used for the zip file.  

This PR hence allows for variable based filenames created using XLST to be used to dynamically name zip files without having to separately perform a list files, xlst and rename after creating the zip file. Even with the later, the zip entry inside of the zip file would have the original static file name instead of the XLST file name for which there is no workaround.

