### PR TITLE
Added support for ODBC connections in Sql, SqlToCsv and SqlToXml Tasks

### DIFF
--- a/src/dotnet/Wexflow.Tasks.Sql/Sql.cs
+++ b/src/dotnet/Wexflow.Tasks.Sql/Sql.cs
@@ -11,6 +11,7 @@ using Npgsql;
 using System.IO;
 using System.Data.OleDb;
 using Teradata.Client.Provider;
+using System.Data.Odbc;
 
 namespace Wexflow.Tasks.Sql
 {
@@ -22,10 +23,11 @@ namespace Wexflow.Tasks.Sql
         MySql,
         Sqlite,
         PostGreSql,
-        Teradata
+        Teradata,
+        Odbc
     }
 
-    public class Sql:Task
+    public class Sql : Task
     {
         public Type DbType { get; set; }
         public string ConnectionString { get; set; }
@@ -152,6 +154,13 @@ namespace Wexflow.Tasks.Sql
                     using (var conn = new TdConnection(ConnectionString))
                     {
                         var comm = new TdCommand(sql, conn);
+                        ExecSql(conn, comm);
+                    }
+                    break;
+                case Type.Odbc:
+                    using (var conn = new OdbcConnection(ConnectionString))
+                    {
+                        var comm = new OdbcCommand(sql, conn);
                         ExecSql(conn, comm);
                     }
                     break;

--- a/src/dotnet/Wexflow.Tasks.Sql/Sql.xml
+++ b/src/dotnet/Wexflow.Tasks.Sql/Sql.xml
@@ -2,7 +2,7 @@
 <Tasks>
   <!--
     Sql is a sequential task that executes a collection of SQL script files. 
-    This task supports Microsoft SQL Server, Microsoft Access, Oracle, MySQL, SQLite, PostgreSQL and Teradata.
+    This task supports Microsoft SQL Server, Microsoft Access, Oracle, MySQL, SQLite, PostgreSQL, Teradata and Odbc.
   -->
   <Task id="$int" name="Sql" description="$string" enabled="true|false">
     <!-- 
@@ -12,8 +12,8 @@
     <Setting name="selectFiles" value="$taskId" />
     <Setting name="selectFiles" value="$taskId" />
     <!-- You can add as many selecteFiles as you want.-->
-    <!-- The database engine type. Possible options: sqlserver|access|oracle|mysql|sqlite|postgresql|teradata-->
-    <Setting name="type" value="sqlserver|access|oracle|mysql|sqlite|postgresql|teradata" />
+    <!-- The database engine type. Possible options: sqlserver|access|oracle|mysql|sqlite|postgresql|teradata|odbc-->
+    <Setting name="type" value="sqlserver|access|oracle|mysql|sqlite|postgresql|teradata|odbc" />
     <!--- The connection string.-->
     <Setting name="connectionString" value="$string" />
     <!-- Optional. It is possible to execute an SQL script through this option.-->

--- a/src/dotnet/Wexflow.Tasks.SqlToCsv/SqlToCsv.cs
+++ b/src/dotnet/Wexflow.Tasks.SqlToCsv/SqlToCsv.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Xml.Linq;
 using Teradata.Client.Provider;
 using Wexflow.Core;
+using System.Data.Odbc;
 
 namespace Wexflow.Tasks.SqlToCsv
 {
@@ -23,7 +24,8 @@ namespace Wexflow.Tasks.SqlToCsv
         MySql,
         Sqlite,
         PostGreSql,
-        Teradata
+        Teradata,
+        Odbc
     }
 
     public class SqlToCsv : Task
@@ -164,6 +166,13 @@ namespace Wexflow.Tasks.SqlToCsv
                 case Type.Teradata:
                     using (var connection = new TdConnection(ConnectionString))
                     using (var command = new TdCommand(sql, connection))
+                    {
+                        ConvertToCsv(connection, command);
+                    }
+                    break;
+                case Type.Odbc:
+                    using (var connection = new OdbcConnection(ConnectionString))
+                    using (var command = new OdbcCommand(sql, connection))
                     {
                         ConvertToCsv(connection, command);
                     }

--- a/src/dotnet/Wexflow.Tasks.SqlToCsv/SqlToCsv.xml
+++ b/src/dotnet/Wexflow.Tasks.SqlToCsv/SqlToCsv.xml
@@ -7,7 +7,7 @@
     columnValue;columnValue;columnValue;...
     ...
     
-    This task supports Microsoft SQL Server, Microsoft Access, Oracle, MySQL, SQLite, PostgreSQL and Teradata.
+    This task supports Microsoft SQL Server, Microsoft Access, Oracle, MySQL, SQLite, PostgreSQL, Teradata and Odbc.
     
     The CSV files generated are loaded by this task so that other tasks can select them through the selectFiles setting.
   -->
@@ -19,8 +19,8 @@
     <Setting name="selectFiles" value="$taskId" />
     <Setting name="selectFiles" value="$taskId" />
     <!-- You can add as many selecteFiles as you want.-->
-    <!-- The database engine type. Possible options: sqlserver|access|oracle|mysql|sqlite|postgresql|teradata-->
-    <Setting name="type" value="sqlserver|access|oracle|mysql|sqlite|postgresql|teradata" />
+    <!-- The database engine type. Possible options: sqlserver|access|oracle|mysql|sqlite|postgresql|teradata|odbc-->
+    <Setting name="type" value="sqlserver|access|oracle|mysql|sqlite|postgresql|teradata|odbc" />
     <!--- The connection string.-->
     <Setting name="connectionString" value="$string" />
     <!-- Optional. It is possible to execute an SQL script through this option.-->

--- a/src/dotnet/Wexflow.Tasks.SqlToXml/SqlToXml.cs
+++ b/src/dotnet/Wexflow.Tasks.SqlToXml/SqlToXml.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Xml.Linq;
 using Teradata.Client.Provider;
 using Wexflow.Core;
+using System.Data.Odbc;
 
 namespace Wexflow.Tasks.SqlToXml
 {
@@ -24,7 +25,8 @@ namespace Wexflow.Tasks.SqlToXml
         MySql,
         Sqlite,
         PostGreSql,
-        Teradata
+        Teradata,
+        Odbc
     }
 
     public class SqlToXml : Task
@@ -153,6 +155,13 @@ namespace Wexflow.Tasks.SqlToXml
                 case Type.Teradata:
                     using (var connenction = new TdConnection(ConnectionString))
                     using (var command = new TdCommand(sql, connenction))
+                    {
+                        ConvertToXml(connenction, command);
+                    }
+                    break;
+                case Type.Odbc:
+                    using (var connenction = new OdbcConnection(ConnectionString))
+                    using (var command = new OdbcCommand(sql, connenction))
                     {
                         ConvertToXml(connenction, command);
                     }

--- a/src/dotnet/Wexflow.Tasks.SqlToXml/SqlToXml.xml
+++ b/src/dotnet/Wexflow.Tasks.SqlToXml/SqlToXml.xml
@@ -17,7 +17,7 @@
       ...
     </Records>
     
-    This task supports Microsoft SQL Server, Microsoft Access, Oracle, MySQL, SQLite, PostgreSQL and Teradata.
+    This task supports Microsoft SQL Server, Microsoft Access, Oracle, MySQL, SQLite, PostgreSQL, Teradata and Odbc.
     
     The XML files generated are loaded by this task so that other tasks can select them through the selectFiles setting.
   -->
@@ -29,8 +29,8 @@
     <Setting name="selectFiles" value="$taskId" />
     <Setting name="selectFiles" value="$taskId" />
     <!-- You can add as many selecteFiles as you want.-->
-    <!-- The database engine type. Possible options: sqlserver|access|oracle|mysql|sqlite|postgresql|teradata-->
-    <Setting name="type" value="sqlserver|access|oracle|mysql|sqlite|postgresql|teradata" />
+    <!-- The database engine type. Possible options: sqlserver|access|oracle|mysql|sqlite|postgresql|teradata|odbc-->
+    <Setting name="type" value="sqlserver|access|oracle|mysql|sqlite|postgresql|teradata|odbc" />
     <!--- The connection string.-->
     <Setting name="connectionString" value="$string" />
     <!-- Optional. It is possible to execute an SQL script through this option.-->


### PR DESCRIPTION
Added support for ODBC connections in Sql, SqlToCsv and SqlToXml Tasks.
This should include also an update on the pages in the Wiki where database supported are listed.
https://github.com/aelassas/Wexflow/wiki/Tasks-documentation#sql-tasks
https://github.com/aelassas/Wexflow/wiki/Sql