### PR TITLE
Incrementing FilesCopier task with PreserveFolderStructFrom and AllowCreateDirectory attributes.

### DIFF
--- a/src/dotnet-core/Wexflow.Tasks.FilesCopier/FilesCopier.cs
+++ b/src/dotnet-core/Wexflow.Tasks.FilesCopier/FilesCopier.cs
@@ -10,12 +10,16 @@ namespace Wexflow.Tasks.FilesCopier
     {
         public string DestFolder { get; private set; }
         public bool Overwrite { get; private set; }
+        public string PreserveFolderStructFrom { get; private set; }
+        public bool AllowCreateDirectory { get; private set; }
 
         public FilesCopier(XElement xe, Workflow wf)
             : base(xe, wf)
         {
             DestFolder = GetSetting("destFolder");
             Overwrite = bool.Parse(GetSetting("overwrite", "false"));
+            PreserveFolderStructFrom = GetSetting("preserveFolderStructFrom");
+            AllowCreateDirectory = bool.Parse(GetSetting("allowCreateDirectory", "true"));
         }
 
         public override TaskStatus Run()
@@ -28,9 +32,31 @@ namespace Wexflow.Tasks.FilesCopier
 
             foreach (FileInf file in files)
             {
-                var destPath = Path.Combine(DestFolder, file.FileName);
+                string destPath;
+                if (!string.IsNullOrWhiteSpace(PreserveFolderStructFrom) &&
+                    file.Path.StartsWith(PreserveFolderStructFrom, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var preservedFolderStruct = Path.GetDirectoryName(file.Path);
+                    preservedFolderStruct = preservedFolderStruct.Length > PreserveFolderStructFrom.Length
+                        ? preservedFolderStruct.Remove(0, PreserveFolderStructFrom.Length)
+                        : string.Empty;
+
+                    if (preservedFolderStruct.StartsWith(Path.DirectorySeparatorChar))
+                        preservedFolderStruct = preservedFolderStruct.Remove(0, 1);
+
+                    destPath = Path.Combine(DestFolder, preservedFolderStruct, file.FileName);
+                }
+                else
+                    destPath = Path.Combine(DestFolder, file.FileName);
+
                 try
                 {
+                    if (AllowCreateDirectory && !Directory.Exists(Path.GetDirectoryName(destPath)))
+                    {
+                        InfoFormat("Creating directory: {0}", Path.GetDirectoryName(destPath));
+                        Directory.CreateDirectory(Path.GetDirectoryName(destPath));
+                    }
+
                     File.Copy(file.Path, destPath, Overwrite);
                     Files.Add(new FileInf(destPath, Id));
                     InfoFormat("File copied: {0} -> {1}", file.Path, destPath);

--- a/src/dotnet-core/Wexflow.Tasks.FilesCopier/FilesCopier.xml
+++ b/src/dotnet-core/Wexflow.Tasks.FilesCopier/FilesCopier.xml
@@ -12,11 +12,25 @@
       copied to the destination folder.
     -->
     <Setting name="selectFiles" value="$taskId" />
-    <Setting name="selectFiles" value="$taskId" />
     <!-- You can add as many selecteFiles as you want.-->
     <!-- The destination folder. For example: C:\MyFolder\-->
     <Setting name="destFolder" value="$string" />
-    <!--- Optional and defualts to false. true to overwrite the files located in the destination folder, false otherwise.-->
+    <!--- Optional and defaults is false. true to overwrite the files located in the destination folder, false otherwise.-->
     <Setting name="overwrite" value="true|false" />
+    <!--
+      Optional and defaults is empty. Preserve Directory Structure from a Source Path Point.
+      For example:
+      Sources:
+        C:\MyFolder\Folder-1\file1.txt
+        C:\MyFolder\Folder-2\file2.txt
+      DestFolder: D:\Backup
+      PreserveFolderStructFrom: C:\MyFolder\
+      Output files path:
+        D:\Backup\Folder-1\file1.txt
+        D:\Backup\Folder-2\file2.txt
+        -->
+    <Setting name="preserveFolderStructFrom" value="$string" />
+    <!-- Optional and defaults is true. true to create destination directtory if not exists. true to fail taks if destination directory not exists  -->
+    <Setting name="allowCreateDirectory" value="true|false" />
   </Task>
 </Tasks>


### PR DESCRIPTION
New attributes to FilesCopier task.
AllowCreateDirectory to auto create destination directory if not exists.
PreserveFolderStructFrom to keep part of source path on destination path.