### PR TITLE
Sceleton for making ServerLogs to the HistoryEntry

### DIFF
--- a/src/dotnet-core/Wexflow.Core.Db/HistoryEntry.cs
+++ b/src/dotnet-core/Wexflow.Core.Db/HistoryEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Wexflow.Core.Db
 {
@@ -12,10 +13,11 @@ namespace Wexflow.Core.Db
         public string Description { get; set; }
         public Status Status { get; set; }
         public DateTime StatusDate { get; set; }
-
+        public List<string> ServerLogs { get; set; }
         public virtual string GetDbId()
         {
             return "-1";
         }
+
     }
 }

--- a/src/dotnet-core/Wexflow.Core/Logger.cs
+++ b/src/dotnet-core/Wexflow.Core/Logger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using log4net;
 
 [assembly: log4net.Config.XmlConfigurator(Watch = true)]
@@ -11,7 +12,7 @@ namespace Wexflow.Core
     public static class Logger
     {
         private static readonly ILog Ilogger = LogManager.GetLogger(typeof(Logger));
-
+        public static List<string> ServerLogs = new List<string>();
         /// <summary>
         /// Logs an information message.
         /// </summary>
@@ -19,6 +20,7 @@ namespace Wexflow.Core
         public static void Info(string msg)
         {
             Ilogger.Info(msg);
+            ServerLogs.Add(msg);
         }
 
         /// <summary>
@@ -29,6 +31,7 @@ namespace Wexflow.Core
         public static void InfoFormat(string msg, params object[] args)
         {
             Ilogger.InfoFormat(msg, args);
+            ServerLogs.Add($"{string.Format(msg, args)}");
         }
 
         /// <summary>
@@ -38,6 +41,7 @@ namespace Wexflow.Core
         public static void Debug(string msg)
         {
             Ilogger.Debug(msg);
+            ServerLogs.Add(msg);
         }
 
         /// <summary>
@@ -48,6 +52,7 @@ namespace Wexflow.Core
         public static void DebugFormat(string msg, params object[] args)
         {
             Ilogger.DebugFormat(msg, args);
+            ServerLogs.Add($"{string.Format(msg, args)}");
         }
 
         /// <summary>
@@ -57,6 +62,7 @@ namespace Wexflow.Core
         public static void Error(string msg)
         {
             Ilogger.Error(msg);
+            ServerLogs.Add(msg);
         }
 
         /// <summary>
@@ -67,6 +73,7 @@ namespace Wexflow.Core
         public static void ErrorFormat(string msg, params object[] args)
         {
             Ilogger.ErrorFormat(msg, args);
+            ServerLogs.Add($"{string.Format(msg, args)}");
         }
 
         /// <summary>
@@ -77,6 +84,7 @@ namespace Wexflow.Core
         public static void Error(string msg, Exception e)
         {
             Ilogger.Error(msg, e);
+            ServerLogs.Add($"{msg} {e.Message}");
         }
 
         /// <summary>
@@ -88,6 +96,7 @@ namespace Wexflow.Core
         public static void ErrorFormat(string msg, Exception e, params object[] args)
         {
             Ilogger.Error(string.Format(msg, args), e);
+            ServerLogs.Add($"{string.Format(msg, args)} {e.Message}");
         }
     }
 }

--- a/src/dotnet-core/Wexflow.Core/Task.cs
+++ b/src/dotnet-core/Wexflow.Core/Task.cs
@@ -123,6 +123,7 @@ namespace Wexflow.Core
             }
 
             Settings = settings.ToArray();
+            ServerLogs = new List<string>();
         }
 
         /// <summary>
@@ -339,6 +340,7 @@ namespace Wexflow.Core
         public void Info(string msg)
         {
             Logger.Info(BuildLogMsg(msg));
+            ServerLogs.Add(BuildLogMsg(msg));
         }
 
         /// <summary>
@@ -349,6 +351,7 @@ namespace Wexflow.Core
         public void InfoFormat(string msg, params object[] args)
         {
             Logger.InfoFormat(BuildLogMsg(msg), args);
+            ServerLogs.Add(BuildLogMsg(msg));
         }
 
         /// <summary>
@@ -358,6 +361,7 @@ namespace Wexflow.Core
         public void Debug(string msg)
         {
             Logger.Debug(BuildLogMsg(msg));
+            ServerLogs.Add(BuildLogMsg(msg));
         }
 
         /// <summary>
@@ -377,6 +381,7 @@ namespace Wexflow.Core
         public void Error(string msg)
         {
             Logger.Error(BuildLogMsg(msg));
+            ServerLogs.Add(BuildLogMsg(msg));
         }
 
         /// <summary>
@@ -409,5 +414,7 @@ namespace Wexflow.Core
         {
             Logger.Error(string.Format(BuildLogMsg(msg), args), e);
         }
+        public List<string> ServerLogs { get; set; }
+
     }
 }

--- a/src/dotnet-core/Wexflow.Core/Workflow.cs
+++ b/src/dotnet-core/Wexflow.Core/Workflow.cs
@@ -1030,6 +1030,8 @@ namespace Wexflow.Core
                         }
 
                         _historyEntry.StatusDate = DateTime.Now;
+                        _historyEntry.ServerLogs = Logger.ServerLogs;
+                        Logger.ServerLogs.Clear();
                         Database.InsertHistoryEntry(_historyEntry);
 
                         Database.DecrementRunningCount();
@@ -1495,6 +1497,8 @@ namespace Wexflow.Core
                     Database.UpdateEntry(entry.GetDbId(), entry);
                     _historyEntry.Status = Db.Status.Stopped;
                     _historyEntry.StatusDate = DateTime.Now;
+                    _historyEntry.ServerLogs = Logger.ServerLogs;
+                    Logger.ServerLogs.Clear();
                     Database.InsertHistoryEntry(_historyEntry);
                     IsDisapproved = false;
                     Jobs.Remove(InstanceId);

--- a/src/dotnet-core/Wexflow.Server/Contracts/HistoryEntry.cs
+++ b/src/dotnet-core/Wexflow.Server/Contracts/HistoryEntry.cs
@@ -1,4 +1,6 @@
-﻿namespace Wexflow.Server.Contracts
+﻿using System.Collections.Generic;
+
+namespace Wexflow.Server.Contracts
 {
     public class HistoryEntry
     {
@@ -17,5 +19,6 @@
 
         //public double StatusDate { get; set; }
         public string StatusDate { get; set; }
+        public List<string> ServerLogs { get; set; }
     }
 }

--- a/src/dotnet-core/Wexflow.Tasks.FilesLoader/FilesLoader.cs
+++ b/src/dotnet-core/Wexflow.Tasks.FilesLoader/FilesLoader.cs
@@ -4,6 +4,7 @@ using System.Xml.Linq;
 using System.Threading;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 namespace Wexflow.Tasks.FilesLoader
 {
@@ -13,7 +14,7 @@ namespace Wexflow.Tasks.FilesLoader
         public string[] FlFiles { get; private set; }
         public string RegexPattern { get; private set; }
         public bool Recursive { get; private set; }
-
+        public List<string> ServerLogs { get; set; }
         public FilesLoader(XElement xe, Workflow wf) : base(xe, wf)
         {
             Folders = GetSettings("folder");
@@ -25,7 +26,6 @@ namespace Wexflow.Tasks.FilesLoader
         public override TaskStatus Run()
         {
             Info("Loading files...");
-
             bool success = true;
 
             try
@@ -43,6 +43,7 @@ namespace Wexflow.Tasks.FilesLoader
                                 var fi = new FileInf(file, Id);
                                 Files.Add(fi);
                                 InfoFormat("File loaded: {0}", file);
+
                             }
                         }
                     }


### PR DESCRIPTION
Have make all logger elements to ServerLogs list<strings>.
The return to the client site i still missing. 
[WebService HistoryEntries](http://localhost:8000/wexflow/searchHistoryEntriesByPageOrderBy?s=&from=1574554043710&to=1574911865210&page=1&entriesCount=10&heo=1)
`0: {Id: "10", WorkflowId: 69, Name: "Workflow_Startup", LaunchType: 0, Description: "Workflow_Startup",…}
Description: "Workflow_Startup"
Id: "10"
LaunchType: 0
Name: "Workflow_Startup"
ServerLogs: null
Status: 2
StatusDate: "28-11-2019 03:31:05"
WorkflowId: 69`
Maybe you can spot the Error why the HistoryEntry.Serverlogs is null, at  ?