### PR TITLE
Example Dockerfile using latest linux release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Linux Alpine environment with .NET runtime.
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
+
+RUN mkdir /opt/wexflow
+
+# Copy local download of wexflow-5.2-linux-dotnet-core.zip
+# which was pre-downloaded and unzipped from https://github.com/aelassas/Wexflow/releases/download/v5.2/wexflow-5.2-linux-dotnet-core.zip
+COPY wexflow-5.2-linux-dotnet-core/ /opt/wexflow/
+
+
+# Instructions below translated from
+# https://github.com/aelassas/Wexflow/wiki/Installation:
+
+# Tell Docker to use this as the base run directory for image:
+# (replaces original 'cd' command in Wexflow installation)
+WORKDIR /opt/wexflow/Wexflow.Server
+
+# Modification of installation instructions so that
+# Docker exposes the wexflow server once it’s run:
+EXPOSE 8000
+ENTRYPOINT ["dotnet", "Wexflow.Server.dll"]


### PR DESCRIPTION
I spent an hour tweaking this and since I have docker experience and I saw 3 issues about it figured someone else might get some time saved. Issue #179.  Not really sure where the main repository maintainer would put the file, but here it is.

To use this right now: 
- download the linux source zip file and extract it to a folder. 
- Run:
`docker build -t wexflow-5.2-linux .`
`docker run -i -t -p 8000:8000  wexflow-5.2-linux:latest`

and then navigate in a web browser to http://localhost:8000 
