### PR TITLE
call server uri instead of localhost

### DIFF
--- a/src/backend/Wexflow.Backend/js/settings.js
+++ b/src/backend/Wexflow.Backend/js/settings.js
@@ -1,3 +1,3 @@
 ﻿Settings = {
-    Uri: "http://localhost:8000/wexflow/"
+    Uri: "http://" + window.location.hostname + ":8000/wexflow/"
 };


### PR DESCRIPTION
Hi,

we had a problem during the connection attempt for the first time, the js variable Settings.Uri reference localhost uri or we need to call server uri,
Problem encoutred when the app is deployed as docker container in aws ec2 instance and called from outside.

changing localhost with window.location.hostname worked for us

maybe need more investigation...

