### PR TITLE
Fix SQLite StatusCount Increment/Decrement

### DIFF
--- a/src/net/Wexflow.Core.Db.SQLite/Db.cs
+++ b/src/net/Wexflow.Core.Db.SQLite/Db.cs
@@ -154,42 +154,23 @@ namespace Wexflow.Core.Db.SQLite
 
         public override void DecrementPendingCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_PendingCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count--;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_PendingCount + " = " + count + ";", conn))
-                    {
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            DecrementStatusCountColumn(StatusCount.ColumnName_PendingCount);
         }
 
         public override void DecrementRunningCount()
+        {
+            DecrementStatusCountColumn(StatusCount.ColumnName_RunningCount);
+        }
+
+        private void DecrementStatusCountColumn(string statusCountColumnName)
         {
             using (var conn = new SQLiteConnection(_connectionString))
             {
                 conn.Open();
 
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_RunningCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
+                using (var command = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + statusCountColumnName + " = " + statusCountColumnName + " - 1;", conn))
                 {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count--;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_RunningCount + " = " + count + ";", conn))
-                    {
-                        command2.ExecuteNonQuery();
-                    }
+                    command.ExecuteNonQuery();
                 }
             }
         }
@@ -1353,176 +1334,55 @@ namespace Wexflow.Core.Db.SQLite
 
         public override void IncrementDisabledCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_DisabledCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_DisabledCount + " = " + count + ";", conn))
-                    {
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_DisabledCount);
         }
 
         public override void IncrementRejectedCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_RejectedCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_RejectedCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_RejectedCount);
         }
 
         public override void IncrementDoneCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_DoneCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_DoneCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_DoneCount);
         }
 
         public override void IncrementFailedCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_FailedCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_FailedCount + " = " + count + ";", conn))
-                    {
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_FailedCount);
         }
 
         public override void IncrementPendingCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_PendingCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_PendingCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_PendingCount);
         }
 
         public override void IncrementRunningCount()
+        {
+            IncrementStatusCountColumn(StatusCount.ColumnName_RunningCount);
+        }
+
+        private void IncrementStatusCountColumn(string statusCountColumnName)
         {
             using (var conn = new SQLiteConnection(_connectionString))
             {
                 conn.Open();
 
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_RunningCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
+                using (var command = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + statusCountColumnName + " = " + statusCountColumnName + " + 1;", conn))
                 {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_RunningCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
+                    command.ExecuteNonQuery();
                 }
             }
         }
 
         public override void IncrementStoppedCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_StoppedCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_StoppedCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_StoppedCount);
         }
 
         public override void IncrementWarningCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_WarningCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_WarningCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_WarningCount);
         }
 
         public override void InsertEntry(Core.Db.Entry entry)

--- a/src/netcore/Wexflow.Core.Db.SQLite/Db.cs
+++ b/src/netcore/Wexflow.Core.Db.SQLite/Db.cs
@@ -154,42 +154,23 @@ namespace Wexflow.Core.Db.SQLite
 
         public override void DecrementPendingCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_PendingCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count--;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_PendingCount + " = " + count + ";", conn))
-                    {
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            DecrementStatusCountColumn(StatusCount.ColumnName_PendingCount);
         }
 
         public override void DecrementRunningCount()
+        {
+            DecrementStatusCountColumn(StatusCount.ColumnName_RunningCount);
+        }
+
+        private void DecrementStatusCountColumn(string statusCountColumnName)
         {
             using (var conn = new SQLiteConnection(_connectionString))
             {
                 conn.Open();
 
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_RunningCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
+                using (var command = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + statusCountColumnName + " = " + statusCountColumnName + " - 1;", conn))
                 {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count--;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_RunningCount + " = " + count + ";", conn))
-                    {
-                        command2.ExecuteNonQuery();
-                    }
+                    command.ExecuteNonQuery();
                 }
             }
         }
@@ -1353,176 +1334,55 @@ namespace Wexflow.Core.Db.SQLite
 
         public override void IncrementDisabledCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_DisabledCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_DisabledCount + " = " + count + ";", conn))
-                    {
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_DisabledCount);
         }
 
         public override void IncrementRejectedCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_RejectedCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_RejectedCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_RejectedCount);
         }
 
         public override void IncrementDoneCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_DoneCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_DoneCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_DoneCount);
         }
 
         public override void IncrementFailedCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_FailedCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_FailedCount + " = " + count + ";", conn))
-                    {
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_FailedCount);
         }
 
         public override void IncrementPendingCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_PendingCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_PendingCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_PendingCount);
         }
 
         public override void IncrementRunningCount()
+        {
+            IncrementStatusCountColumn(StatusCount.ColumnName_RunningCount);
+        }
+
+        private void IncrementStatusCountColumn(string statusCountColumnName)
         {
             using (var conn = new SQLiteConnection(_connectionString))
             {
                 conn.Open();
 
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_RunningCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
+                using (var command = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + statusCountColumnName + " = " + statusCountColumnName + " + 1;", conn))
                 {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_RunningCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
+                    command.ExecuteNonQuery();
                 }
             }
         }
 
         public override void IncrementStoppedCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_StoppedCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_StoppedCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_StoppedCount);
         }
 
         public override void IncrementWarningCount()
         {
-            using (var conn = new SQLiteConnection(_connectionString))
-            {
-                conn.Open();
-
-                using (var command1 = new SQLiteCommand("SELECT " + StatusCount.ColumnName_WarningCount + " FROM " + Core.Db.StatusCount.DocumentName + ";", conn))
-                {
-
-                    var count = (long)command1.ExecuteScalar();
-
-                    count++;
-
-                    using (var command2 = new SQLiteCommand("UPDATE " + Core.Db.StatusCount.DocumentName + " SET " + StatusCount.ColumnName_WarningCount + " = " + count + ";", conn))
-                    {
-
-                        command2.ExecuteNonQuery();
-                    }
-                }
-            }
+            IncrementStatusCountColumn(StatusCount.ColumnName_WarningCount);
         }
 
         public override void InsertEntry(Core.Db.Entry entry)


### PR DESCRIPTION
I encountered a bug where the status count on the dashboard will go negative.  This is caused by having multiple jobs on a cron schedule kick off at the same time.  

For example, when multiple jobs start on multiple threads, the current counter is first read into memory before being incremented and since there is no synchronization code in these methods they all read running count 0 and increment it, then update the database to be 1. So there could be multiple jobs running but the running counter is only set to 1.  Then when the jobs finish at different times they decrement and the counters goes negative. If you let SQLite handle the increment by doing

`UPDATE tablename SET counter= counter + 1`

then it will take care of synchronizing the counter variable.

![image](https://user-images.githubusercontent.com/16690206/80828697-55994d00-8bab-11ea-9ef5-64d3918ece48.png)
