### PR TITLE
fix: use runtime not sdk for smaller docker image

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Linux Alpine environment with .NET runtime
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine
 
 RUN mkdir /opt/wexflow
 

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       http-server --cors -p 8011
 
   wexflow:
-    image: mcr.microsoft.com/dotnet/core/sdk:3.1-alpine
+    image: mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine
     ports:
       - 8000:8000
     volumes:


### PR DESCRIPTION
## Proposed changes

Smaller docker image by using the runtime and not the SDK since we aren't building anything.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/aelassas/Wexflow/blob/master/.github/CONTRIBUTING.md) doc
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published
